### PR TITLE
change to throw 401 when invalid token provided

### DIFF
--- a/src/middleware/verifyToken.js
+++ b/src/middleware/verifyToken.js
@@ -4,7 +4,7 @@ import Error from './error/ErrorHandler';
 const verifyToken = (req, res, next) => {
   const token = req.header('auth-token');
   if (!token) {
-    next(Error.unauthorized('Access denied'));
+    next(Error.unauthorized('No access token provided'));
     return;
   }
   try {
@@ -12,7 +12,7 @@ const verifyToken = (req, res, next) => {
     req.user = verified;
     next();
   } catch (error) {
-    next(Error.badRequest('Invalid token'));
+    next(Error.unauthorized('Invalid token'));
   }
 };
 


### PR DESCRIPTION
just found that when invalid token is provided, verifytoken was throwing bad request (400) error instead of 401 so fixed it to throw 401 with appropriate message. 